### PR TITLE
Allow caller to pass scope and reduce default scopes to RW for google.

### DIFF
--- a/google/config.go
+++ b/google/config.go
@@ -3,6 +3,7 @@ package google
 import (
 	"errors"
 	"net/url"
+	"strings"
 
 	"github.com/graymeta/stow"
 	"golang.org/x/net/context"
@@ -17,6 +18,7 @@ const (
 	// The service account json blob
 	ConfigJSON      = "json"
 	ConfigProjectId = "project_id"
+	ConfigScopes    = "scopes"
 )
 
 func init() {
@@ -58,7 +60,12 @@ func init() {
 func newGoogleStorageClient(config stow.Config) (*storage.Service, error) {
 	json, _ := config.Config(ConfigJSON)
 
-	jwtConf, err := google.JWTConfigFromJSON([]byte(json), storage.DevstorageFullControlScope)
+	scopes := []string{storage.DevstorageReadWriteScope}
+	if s, ok := config.Config(ConfigScopes); ok {
+		scopes = strings.Split(s, ",")
+	}
+
+	jwtConf, err := google.JWTConfigFromJSON([]byte(json), scopes...)
 
 	service, err := storage.New(jwtConf.Client(context.Background()))
 	if err != nil {


### PR DESCRIPTION
ref:
https://cloud.google.com/storage/docs/json_api/v1/buckets/insert