### PR TITLE
Add SSL support for S3 compatible custom endpoint

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -15,13 +15,46 @@
 
 [[projects]]
   name = "github.com/Azure/go-autorest"
-  packages = ["autorest","autorest/adal","autorest/azure","autorest/date"]
+  packages = [
+    "autorest",
+    "autorest/adal",
+    "autorest/azure",
+    "autorest/date"
+  ]
   revision = "77a52603f06947221c672f10275abc9bf2c7d557"
   version = "v8.3.0"
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
-  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/restxml","private/protocol/xml/xmlutil","service/s3","service/sts"]
+  packages = [
+    "aws",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/stscreds",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/shareddefaults",
+    "private/protocol",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/restxml",
+    "private/protocol/xml/xmlutil",
+    "service/s3",
+    "service/s3/s3iface",
+    "service/s3/s3manager",
+    "service/sts"
+  ]
   revision = "1850f427c33c2558a2118dc55c1cf95a633d7432"
   version = "v1.10.27"
 
@@ -76,30 +109,55 @@
 [[projects]]
   branch = "release-branch.go1.8"
   name = "golang.org/x/net"
-  packages = ["context","context/ctxhttp"]
+  packages = [
+    "context",
+    "context/ctxhttp"
+  ]
   revision = "186fd3fc8194a5e9980a82230d69c1ff7134229f"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/oauth2"
-  packages = [".","google","internal","jws","jwt"]
+  packages = [
+    ".",
+    "google",
+    "internal",
+    "jws",
+    "jwt"
+  ]
   revision = "9a379c6b3e95a790ffc43293c2a78dee0d7b6e20"
 
 [[projects]]
   branch = "master"
   name = "google.golang.org/api"
-  packages = ["gensupport","googleapi","googleapi/internal/uritemplates","storage/v1"]
+  packages = [
+    "gensupport",
+    "googleapi",
+    "googleapi/internal/uritemplates",
+    "storage/v1"
+  ]
   revision = "98825bb0065da4054e5da6db34f5fc598e50bc24"
 
 [[projects]]
   name = "google.golang.org/appengine"
-  packages = [".","internal","internal/app_identity","internal/base","internal/datastore","internal/log","internal/modules","internal/remote_api","internal/urlfetch","urlfetch"]
+  packages = [
+    ".",
+    "internal",
+    "internal/app_identity",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/modules",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch"
+  ]
   revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
   version = "v1.0.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9669b6203ee98d781a69726537e19d7fbfb1bdf3441ba58111d3208fff0c225f"
+  inputs-digest = "1afa9d34646af41ce08878b21b1946011d2315793158b830a12a55e5ca1e2b7e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/s3/config.go
+++ b/s3/config.go
@@ -48,9 +48,9 @@ const (
 	// used for e.g. minio.io
 	ConfigEndpoint = "endpoint"
 
-	// ConfigCACertDir is optional config value for providing cacerts for custom endpoint like minio
-	// provide root CAs certificate directory to establish TLS secure connection
-	ConfigCACertDir = "cacert_dir"
+	// ConfigCACertFile is optional config value for providing path to cacert file for custom endpoint like Minio
+	// to establish TLS secure connection
+	ConfigCACertFile = "cacert_file"
 
 	// ConfigDisableSSL is optional config value for disabling SSL support on custom endpoints
 	// Its default value is "false", to disable SSL set it to "true".
@@ -167,17 +167,17 @@ func newS3Client(config stow.Config) (client *s3.S3, endpoint string, err error)
 		awsConfig.WithDisableSSL(true)
 	}
 
-	cacertDir, ok := config.Config(ConfigCACertDir)
+	cacertFile, ok := config.Config(ConfigCACertFile)
 	if ok {
-		awsConfig.HTTPClient.Transport, err = newTLSTransport(cacertDir)
+		awsConfig.HTTPClient.Transport, err = newSecureTransport(cacertFile)
 		if err != nil {
 			return nil, "", err
 		}
 	}
 
-	sess := session.New(awsConfig)
-	if sess == nil {
-		return nil, "", errors.New("creating the S3 session")
+	sess, err := session.NewSession(awsConfig)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create S3 session. Reason: %s", err)
 	}
 
 	s3Client := s3.New(sess)
@@ -185,8 +185,8 @@ func newS3Client(config stow.Config) (client *s3.S3, endpoint string, err error)
 	return s3Client, endpoint, nil
 }
 
-func newTLSTransport(cacertDir string) (http.RoundTripper, error) {
-	if cacertDir == "" {
+func newSecureTransport(cacertFile string) (http.RoundTripper, error) {
+	if cacertFile == "" {
 		return nil, fmt.Errorf("invalid root certificate directory")
 	}
 
@@ -207,12 +207,12 @@ func newTLSTransport(cacertDir string) (http.RoundTripper, error) {
 
 	pool := x509.NewCertPool()
 
-	certData, err := ioutil.ReadFile(cacertDir)
+	cacert, err := ioutil.ReadFile(cacertFile)
 	if err != nil {
 		return nil, errors.Errorf("unable to read root certificate: %v", err)
 	}
-	if ok := pool.AppendCertsFromPEM(certData); !ok {
-		return nil, errors.Errorf("cannot parse root certificate from %q", cacertDir)
+	if ok := pool.AppendCertsFromPEM(cacert); !ok {
+		return nil, errors.Errorf("cannot parse root certificate from %q", cacertFile)
 	}
 	tr.TLSClientConfig.RootCAs = pool
 

--- a/s3/config.go
+++ b/s3/config.go
@@ -48,9 +48,9 @@ const (
 	// used for e.g. minio.io
 	ConfigEndpoint = "endpoint"
 
-	// ConfigCACert is optional config value for providing cacerts for custom endpoint like minio
+	// ConfigCACertDir is optional config value for providing cacerts for custom endpoint like minio
 	// provide root CAs certificate directory to establish TLS secure connection
-	ConfigCACert = "cacert"
+	ConfigCACertDir = "cacert_dir"
 
 	// ConfigDisableSSL is optional config value for disabling SSL support on custom endpoints
 	// Its default value is "false", to disable SSL set it to "true".
@@ -167,7 +167,7 @@ func newS3Client(config stow.Config) (client *s3.S3, endpoint string, err error)
 		awsConfig.WithDisableSSL(true)
 	}
 
-	cacertDir, ok := config.Config(ConfigCACert)
+	cacertDir, ok := config.Config(ConfigCACertDir)
 	if ok {
 		awsConfig.HTTPClient.Transport, err = newTLSTransport(cacertDir)
 		if err != nil {

--- a/s3/config.go
+++ b/s3/config.go
@@ -1,9 +1,15 @@
 package s3
 
 import (
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
 	"time"
+
+	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -41,6 +47,10 @@ const (
 	// ConfigEndpoint is optional config value for changing s3 endpoint
 	// used for e.g. minio.io
 	ConfigEndpoint = "endpoint"
+
+	// ConfigCACert is optional config value for providing cacerts for custom endpoint like minio
+	// provide root CAs certificate directory to establish TLS secure connection
+	ConfigCACert = "cacert"
 
 	// ConfigDisableSSL is optional config value for disabling SSL support on custom endpoints
 	// Its default value is "false", to disable SSL set it to "true".
@@ -157,6 +167,14 @@ func newS3Client(config stow.Config) (client *s3.S3, endpoint string, err error)
 		awsConfig.WithDisableSSL(true)
 	}
 
+	cacertDir, ok := config.Config(ConfigCACert)
+	if ok {
+		awsConfig.HTTPClient.Transport, err = newTLSTransport(cacertDir)
+		if err != nil {
+			return nil, "", err
+		}
+	}
+
 	sess := session.New(awsConfig)
 	if sess == nil {
 		return nil, "", errors.New("creating the S3 session")
@@ -165,4 +183,38 @@ func newS3Client(config stow.Config) (client *s3.S3, endpoint string, err error)
 	s3Client := s3.New(sess)
 
 	return s3Client, endpoint, nil
+}
+
+func newTLSTransport(cacertDir string) (http.RoundTripper, error) {
+	if cacertDir == "" {
+		return nil, fmt.Errorf("invalid root certificate directory")
+	}
+
+	tr := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		TLSClientConfig:       &tls.Config{},
+	}
+
+	pool := x509.NewCertPool()
+
+	certData, err := ioutil.ReadFile(cacertDir)
+	if err != nil {
+		return nil, errors.Errorf("unable to read root certificate: %v", err)
+	}
+	if ok := pool.AppendCertsFromPEM(certData); !ok {
+		return nil, errors.Errorf("cannot parse root certificate from %q", cacertDir)
+	}
+	tr.TLSClientConfig.RootCAs = pool
+
+	return tr, nil
 }


### PR DESCRIPTION
This PR added option to provide SSL certificate for TLS secure S3 compatible custom endpoint (i.e Minio)